### PR TITLE
Support Raspberry Pi arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ mongo:
 
 This way you should be able to use other tools that would like direct access.
 
+## Run on Raspberry Pi arm64
+If you use a 64bit Kernel you need to use a compatible mongo docker container. For this reason you might use the alternative docker-compose file 
+
+´docker-compose -f docker-compose.arm64.yml up -d´
+
+
 ## Configure your Uploader
 To upload your CGM Data to your Nightscout system, this image is designed to use the REST-API Upload
 only! The internal Mongo Port is not exposed by default.

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -1,4 +1,5 @@
-version: "3.4"
+version: '3.4'
+services:
   nightscout:
     image: dhermanns/rpi-nightscout:latest
     environment:
@@ -23,12 +24,12 @@ version: "3.4"
       - /home/pi/docker/rpi-nightscout:/var/opt/ssl/:ro
     restart: always
   mongo:
-    image:  arm64v8/mongo:latest
-    volumes:                                                        
+    image: arm64v8/mongo:latest
+    volumes:
       - ./data:/data/db                                                                      
-    ports:                                              
-      - "27017:27017"                                                                                     
-      - "27018:27018"                                                                                            
-      - "27019:27019"                                                                               
-      - "28017:28017" 
+    ports:
+      - "27017:27017"
+      - "27018:27018"
+      - "27019:27019"
+      - "28017:28017"
     restart: always

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -1,0 +1,34 @@
+version: "3.4"
+  nightscout:
+    image: dhermanns/rpi-nightscout:latest
+    environment:
+      TZ: Europe/Berlin
+      MONGO_CONNECTION: mongodb://mongo:27017/nightscout
+      API_SECRET: mypassword123
+      BG_HIGH: 220
+      BG_LOW: 60
+      BG_TARGET_TOP: 180
+      BG_TARGET_BOTTOM: 80
+      INSECURE_USE_HTTP: "true"
+#      SSL_KEY: /var/opt/ssl/server.key
+#      SSL_CERT: /var/opt/ssl/serverchain.crt
+#      SSL_CA: /var/opt/ssl/cachain.crt
+      AUTH_DEFAULT_ROLES: readable devicestatus-upload
+      ENABLE: alexa rawbg
+    ports:
+      - "1337:1337"
+    depends_on:
+      - mongo
+    volumes:
+      - /home/pi/docker/rpi-nightscout:/var/opt/ssl/:ro
+    restart: always
+  mongo:
+    image:  arm64v8/mongo:latest
+    volumes:                                                        
+      - ./data:/data/db                                                                      
+    ports:                                              
+      - "27017:27017"                                                                                     
+      - "27018:27018"                                                                                            
+      - "27019:27019"                                                                               
+      - "28017:28017" 
+    restart: always


### PR DESCRIPTION
Hi, I just got this project up and running on my Raspberry Pi 4 with 64bit kernel. I created a new docker-compose file which uses another mongo db container. I'm not sure how it would be possible to have this in one docker-compose file.

For this reason I added a hint in the readme, to show how to use the arm64 docker-compose file.

I would be happy to help out here. :)