### PR TITLE
Update nightscout (CGM) to 14.2.5 and change base image to node:12-buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # CGM Remote Monitor Dockerfile
 #
-# https://github.com/pkolyvas/rpi-nightscout
+# https://github.com/dhermanns/rpi-nightscout
 #
 
 # Pull base image.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ USER node
 # install the application
 RUN git clone https://github.com/nightscout/cgm-remote-monitor.git . && \
     git checkout tags/14.2.5 && \
-    rm package-lock.json && \
     npm install && \
     npm run postinstall && \
     npm run env && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 #
 # CGM Remote Monitor Dockerfile
 #
-# https://github.com/dhermanns/rpi-nightscout
+# https://github.com/pkolyvas/rpi-nightscout
 #
 
 # Pull base image.
-FROM node:lts-buster
+FROM node:12-buster
 
 # install git and npm
 RUN apt-get update && apt-get install -y software-properties-common python g++ make git
@@ -21,7 +21,8 @@ USER node
 
 # install the application
 RUN git clone https://github.com/nightscout/cgm-remote-monitor.git . && \
-    git checkout tags/14.2.2 && \
+    git checkout tags/14.2.5 && \
+    rm package-lock.json && \
     npm install && \
     npm run postinstall && \
     npm run env && \


### PR DESCRIPTION
Thanks for all the hard work @dhermanns. I made an update for my own use and thought I’d share it here in case you were interested.

This PR updates the following:

- Node base image to `12-buster` from `lts-buster` as `lts-buster` now provides Node@16. 
- Nightscout to `14.2.5` (latest release) with updated Dexcom bridge to restore trend arrows

Docker image: `eyeoh/rpi-nightscout:14.2.5` 